### PR TITLE
Setup Git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm commitlint ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+pnpm lint:ts
+pnpm lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier . --write"
+    "format": "prettier . --write",
+    "prepare": "husky"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.12",
@@ -36,6 +37,7 @@
     "eslint-config-next": "^15.2.1",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "husky": "^9.1.7",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "typescript": "^5.8.2"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:ts": "tsc --noEmit",
     "format": "prettier . --write",
     "prepare": "husky",
     "commitlint": "commitlint --edit"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier . --write",
-    "prepare": "husky"
+    "prepare": "husky",
+    "commitlint": "commitlint --edit"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.22.0(jiti@2.4.2))
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -1159,6 +1162,11 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3284,6 +3292,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
This pull request introduces several changes to improve the development workflow by adding Husky for Git hooks and enhancing the linting setup. The most important changes are summarized below:

### Husky Integration:

* Added Husky to the project dependencies in `package.json` and configured it to run on the `prepare` script. (`package.json` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R14) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R42)
* Configured a commit message hook to use `commitlint` in `.husky/commit-msg`. (`.husky/commit-msg` [.husky/commit-msgR1](diffhunk://#diff-292bac03df29207ee254ba91cfc30951b10c50c0a9fff3a0768778cebe5f4c4aR1))
* Added a pre-commit hook to run TypeScript and general linting in `.husky/pre-commit`. (`.husky/pre-commit` [.husky/pre-commitR1-R2](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR1-R2))

### Linting Enhancements:

* Added a new script `lint:ts` to `package.json` to run TypeScript linting without emitting output. (`package.json` [package.jsonL11-R14](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R14))

### Dependency Updates:

* Updated `pnpm-lock.yaml` to include Husky and ensure all dependencies are correctly locked. (`pnpm-lock.yaml` [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR81-R83) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1166-R1170) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3296-R3297)